### PR TITLE
feat: Persist theme preference using AsyncStorage

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,24 +1,58 @@
-import React, { createContext, useState, ReactNode } from "react";
+import React, { createContext, useState, useEffect, ReactNode } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 interface ThemeContextType {
   theme: string;
   toggleTheme: () => void;
+  isLoadingTheme: boolean;
 }
 
 export const ThemeContext = createContext<ThemeContextType>({
   theme: "light",
   toggleTheme: () => {},
+  isLoadingTheme: true,
 });
 
-export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState("light"); // Tema padrão fixo como "light"
+const THEME_STORAGE_KEY = "@theme";
 
-  const toggleTheme = () => {
-    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState("light");
+  const [isLoadingTheme, setIsLoadingTheme] = useState(true);
+
+  useEffect(() => {
+    const loadTheme = async () => {
+      try {
+        const storedTheme = await AsyncStorage.getItem(THEME_STORAGE_KEY);
+        if (storedTheme) {
+          setTheme(storedTheme);
+        }
+      } catch (error) {
+        console.error("Failed to load theme from storage", error);
+        // Mantém o tema padrão 'light' em caso de erro
+      } finally {
+        setIsLoadingTheme(false);
+      }
+    };
+
+    loadTheme();
+  }, []);
+
+  const toggleTheme = async () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    try {
+      await AsyncStorage.setItem(THEME_STORAGE_KEY, newTheme);
+    } catch (error) {
+      console.error("Failed to save theme to storage", error);
+    }
   };
 
+  if (isLoadingTheme) {
+    return null; // Ou um componente de loading, se preferir
+  }
+
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, isLoadingTheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
Implemented theme persistence by leveraging AsyncStorage in ThemeContext.

- The selected theme (light or dark) is now saved to AsyncStorage when changed.
- On app startup, the theme is loaded from AsyncStorage.
- Defaults to light theme if no preference is stored (e.g., first launch).
- Added an isLoadingTheme state to prevent UI flickering during initial theme load.