### PR TITLE
fix: Resolve bundling error by removing toast imports

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,8 +5,8 @@ import { ListProvider } from "../src/context/ListContext";
 import { ThemeContext, ThemeProvider } from "../src/context/ThemeContext";
 import { Cores } from "../constants/Colors"; // Importar Cores centralizadas
 import { View } from "react-native"; // Necessário para o componente de loading
-import Toast from 'react-native-toast-message';
-import { toastConfig } from '../src/utils/toastService'; // Importar a configuração do toast
+// import Toast from 'react-native-toast-message'; // Garantir que esta linha seja removida ou comentada
+// import { toastConfig } from '../src/utils/toastService'; // Esta já deve estar removida
 
 function TabsLayout() {
   const { theme, isLoadingTheme } = useContext(ThemeContext); // Adicionado isLoadingTheme


### PR DESCRIPTION
- Removed remaining import statements for 'react-native-toast-message' and 'toastConfig' from app/_layout.tsx to fix the Metro Bundler "Unable to resolve" error.
- This commit finalizes the reversion from the toast notification system back to standard Alert.alert, ensuring all related code artifacts are cleaned up.